### PR TITLE
Add NetAppManageability::Error

### DIFF
--- a/lib/net_app_manageability/api/error.rb
+++ b/lib/net_app_manageability/api/error.rb
@@ -1,6 +1,6 @@
 module NetAppManageability
   class API
-    class Error < RuntimeError
+    class Error < NetAppManageability::Error
     end
   end
 end

--- a/lib/net_app_manageability/error.rb
+++ b/lib/net_app_manageability/error.rb
@@ -1,0 +1,4 @@
+module NetAppManageability
+  class Error < RuntimeError
+  end
+end

--- a/lib/net_app_manageability/types.rb
+++ b/lib/net_app_manageability/types.rb
@@ -1,3 +1,4 @@
+require_relative 'error'
 require_relative 'api/error'
 require_relative 'nam_array'
 require_relative 'nam_hash'


### PR DESCRIPTION
Also changed `NetAppManageability::API::Error` to inherit from `NetAppManageability::Error`.

This way, a caller can rescue either the more general `NetAppManageability::Error` or the more specific `NetAppManageability::API::Error`.
